### PR TITLE
Fix use of reserved awk name `isarray`

### DIFF
--- a/src/libxlibtrace-functions.h.sh
+++ b/src/libxlibtrace-functions.h.sh
@@ -81,7 +81,7 @@ function isconst(t) {
 	return (t ~ /^[cC][oO][nN][sS][tT][ 	]/);
 }
 
-function isarray(t) {
+function isarray2(t) {
 	return (t ~ /\[.*\]$/);
 }
 
@@ -90,7 +90,7 @@ function makedefn(t, n) {
 		return sprintf("%s", t);
 	} else if (isfunctionpointer(t)) {
 		return gensub("^(.*\\(\\*)(\\).*)$", "\\1"n"\\2", "", t);
-	} else if (isarray(t)) {
+	} else if (isarray2(t)) {
 		return gensub("^(.*)(\\[.*\\])$", "\\1"n"\\2", "", t);
 	} else {
 		return sprintf("%s %s", t, n);


### PR DESCRIPTION
Closes https://github.com/devkev/xlibtrace/issues/1

Sorry I couldn't think of a better name.
